### PR TITLE
Only show request details if there is a request

### DIFF
--- a/epidurio/templates/records/epidural_insertion.html
+++ b/epidurio/templates/records/epidural_insertion.html
@@ -1,1 +1,3 @@
-Procedure: [[ item.insertion_date_time | shortDate ]]<br />
+<span ng-show="item.insertion_date_time">
+  Procedure: [[ item.insertion_date_time | shortDate ]]<br />
+</span>

--- a/epidurio/templates/records/epidural_request.html
+++ b/epidurio/templates/records/epidural_request.html
@@ -1,1 +1,4 @@
-Requested: [[ item.request_date_time | shortDate ]](<span minutes-since="item.request_date_time"></span>)<br />
+<span ng-show="item.request_date_time">
+  Requested: [[ item.request_date_time | shortDate ]]
+  (<span minutes-since="item.request_date_time"></span>)
+</span>


### PR DESCRIPTION
Because it's currently a singleton, you can have an `EpiduralRequest` instance before you have a request. 

That means you need the display template to check for values.

If you don't do this, the EpidurialRequest panel shows like this which is silly:

```
Request: ()
```