### PR TITLE
Move FHIR connection settings to settings.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ Port of epidur.io using the [Opal](https://github.com/openhealthcare/opal) healt
 
 
 ### FHIR integration
+
 * Epidur.io simply uses the Python `Requests` library to interface with the FHIR server.
 * We did experiment with the FHIRClient [fhirclient](https://github.com/smart-on-fhir/client-py) library, which is designed to provide a Pythonic, object oriented API for the FHIR server, however for our purposes it was simply much more than we needed.
+* The FHIR server details can be adjusted by overriding the setting `FHIR_API_DETAILS`
 
 
 ### Deploying your new Opal application to Heroku for testing/demo

--- a/epidurio/api.py
+++ b/epidurio/api.py
@@ -1,4 +1,5 @@
 import requests
+from django.conf import settings
 from django.utils.dateparse import parse_date
 from opal.core.api import OPALRouter
 from opal.core.api import LoginRequiredViewset
@@ -8,17 +9,6 @@ from opal.core import exceptions
 
 class FhirServerSearchViewSet(LoginRequiredViewset):
     base_name = r'search'
-
-    API_DETAILS = {
-        'cerner_open': {
-            'api_base_url':        'https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/',
-            'ident_token_prefix':  'urn:oid:2.2.2.2.2.2'
-        },
-        'smart_open': {
-            'api_base_url':        'https://sb-fhir-dstu2.smarthealthit.org/api/smartdstu2/open/',
-            'ident_token_prefix':  ''
-        }
-    }
 
     PATIENT_FOUND_IN_FHIR = "patient_found_in_fhir"
     PATIENT_NOT_FOUND = "patient_not_found"
@@ -60,8 +50,9 @@ class FhirServerSearchViewSet(LoginRequiredViewset):
 
     def get_data_from_fhir_server(self, cerner_mrn):
         query_type = "Patient"
-        url = self.API_DETAILS['cerner_open']['api_base_url'] + query_type
-        identifier_string = self.API_DETAILS['cerner_open']['ident_token_prefix'] + "|" + cerner_mrn
+        url = settings.FHIR_API_DETAILS['cerner_open']['api_base_url'] + query_type
+        token_prefix = settings.FHIR_API_DETAILS['cerner_open']['ident_token_prefix']
+        identifier_string = token_prefix + "|" + cerner_mrn
         querystring = {"identifier": identifier_string}
         headers = {'accept': "application/json",}
         response = requests.request("GET", url, headers=headers, params=querystring)

--- a/epidurio/settings.py
+++ b/epidurio/settings.py
@@ -290,6 +290,20 @@ REST_FRAMEWORK = {
 #     ('text/x-scss', 'sass --scss {infile} {outfile}'),
 # )
 
+##################### Begin Epidur.io Settings ###############################
+FHIR_API_DETAILS = {
+    'cerner_open': {
+        'api_base_url':        'https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/',
+        'ident_token_prefix':  'urn:oid:2.2.2.2.2.2'
+    },
+    'smart_open': {
+        'api_base_url':        'https://sb-fhir-dstu2.smarthealthit.org/api/smartdstu2/open/',
+        'ident_token_prefix':  ''
+    }
+}
+##################### End Epidur.io Settings ###############################
+
+
 try:
     from local_settings import *
 except ImportError:


### PR DESCRIPTION
I'd expect connection details / base URLs for upstream etc to live in `settings.py` rather than your API code...